### PR TITLE
moved body.close() after err check

### DIFF
--- a/asyncsgd/param_client.go
+++ b/asyncsgd/param_client.go
@@ -72,11 +72,11 @@ func (p *ParamClient) WriteParams(g autofunc.Gradient, v []*autofunc.Variable) e
 		return err
 	}
 	resp, err := http.DefaultClient.Do(req)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return err
+	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
 	}
 	if resp.StatusCode != 200 {
 		errStr, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
I moved the err check before the body.Close() for the URL param so if there is an error with the URL it doesn't panic, and instead shows an actual error message.

```
MacBookAir:dist_train colinadler$ ./dist_train train localhost:8080 test.csv
2016/12/02 01:40:05 Loading samples...
2016/12/02 01:40:05 Partitioning 48 samples...
2016/12/02 01:40:18 iter 0: validation=12882.163638 cost=13356.401346 last=0.000000
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x40 pc=0x11ae8d]

goroutine 1 [running]:
panic(0x43bf00, 0xc8200100c0)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/unixpickle/sgd/asyncsgd.(*ParamClient).WriteParams(0xc820028080, 0xc89a050ff0, 0xc820082000, 0x21, 0x28, 0x0, 0x0)
	/Users/colinadler/go/src/github.com/unixpickle/sgd/asyncsgd/param_client.go:75 +0x3ad
github.com/unixpickle/sgd/asyncsgd.(*Slave).Sync(0xc820054070, 0x0, 0x0)
	/Users/colinadler/go/src/github.com/unixpickle/sgd/asyncsgd/slave.go:60 +0x7d
github.com/unixpickle/sgd/asyncsgd.(*Slave).Loop(0xc820054070, 0x4, 0xc8391d9e00, 0x0, 0x0)
	/Users/colinadler/go/src/github.com/unixpickle/sgd/asyncsgd/slave.go:92 +0xec
main.Train(0x7fff5fbffb6b, 0xe, 0x7fff5fbffb7a, 0x8)
	/Users/colinadler/go/src/github.com/ThyLeader/dist_train/train.go:76 +0x9c3
main.main()
	/Users/colinadler/go/src/github.com/ThyLeader/dist_train/main.go:15 +0x3e2
```